### PR TITLE
fix(tui): composer arrow-key navigation and slash command input handling

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -613,7 +613,16 @@ export function StepCliTuiScreen(props: StepCliTuiScreenProps) {
 
       const currentComposer = readComposerSnapshot();
       if (currentComposer.value.includes("\n")) {
-        return;
+        const firstLineEnd = currentComposer.value.indexOf("\n");
+        if (currentComposer.cursorIndex > firstLineEnd) {
+          return;
+        }
+
+        if (currentComposer.cursorIndex > 0) {
+          key.preventDefault();
+          replaceComposer({ ...currentComposer, cursorIndex: 0 });
+          return;
+        }
       }
 
       key.preventDefault();
@@ -638,7 +647,19 @@ export function StepCliTuiScreen(props: StepCliTuiScreenProps) {
 
       const currentComposer = readComposerSnapshot();
       if (currentComposer.value.includes("\n")) {
-        return;
+        const lastLineStart = currentComposer.value.lastIndexOf("\n") + 1;
+        if (currentComposer.cursorIndex < lastLineStart) {
+          return;
+        }
+
+        if (currentComposer.cursorIndex < currentComposer.value.length) {
+          key.preventDefault();
+          replaceComposer({
+            ...currentComposer,
+            cursorIndex: currentComposer.value.length,
+          });
+          return;
+        }
       }
 
       key.preventDefault();
@@ -697,11 +718,14 @@ export function StepCliTuiScreen(props: StepCliTuiScreenProps) {
 
     if (isComposerSubmitKey(key)) {
       key.preventDefault();
-      const autocompleteSlashCommand = shouldAutocompleteSlashCommand(
-        slashPaletteState,
-      )
-        ? slashPaletteState.activeCommand
-        : null;
+      const composerHasArguments = /^\S+\s+\S/.test(
+        readComposerSnapshot().value.trimStart(),
+      );
+      const autocompleteSlashCommand =
+        !composerHasArguments &&
+        shouldAutocompleteSlashCommand(slashPaletteState)
+          ? slashPaletteState.activeCommand
+          : null;
       if (autocompleteSlashCommand) {
         applyComposerEdit(
           applySlashCommandSelection(
@@ -865,7 +889,7 @@ export function StepCliTuiScreen(props: StepCliTuiScreenProps) {
 
     if (trimmed.startsWith("/")) {
       const clearComposer = await handleSlashCommand(trimmed);
-      if (clearComposer) {
+      if (clearComposer && readComposerSnapshot().value === inputContent) {
         applyComposerEdit({
           value: "",
           cursorIndex: 0,
@@ -1322,10 +1346,6 @@ export function StepCliTuiScreen(props: StepCliTuiScreenProps) {
         tone: "success",
         label: "Goal",
         detail: formatTuiGoalDetail(result.goal),
-      });
-      replaceComposer({
-        value: "",
-        cursorIndex: 0,
       });
       return true;
     } catch (error) {

--- a/src/tui/composer-state.test.ts
+++ b/src/tui/composer-state.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  browseComposerHistory,
+  rememberSubmittedComposerValue,
+} from "./composer-state.js";
+import type {
+  StepCliTuiComposerHistoryState,
+  StepCliTuiComposerState,
+} from "./types.js";
+
+const emptyHistory: StepCliTuiComposerHistoryState = {
+  entries: [],
+  browsingIndex: null,
+  draftBeforeBrowsing: null,
+};
+
+function composerOf(value: string, cursorIndex = value.length) {
+  return { value, cursorIndex };
+}
+
+function historyOf(
+  values: string[],
+  overrides?: Partial<StepCliTuiComposerHistoryState>,
+): StepCliTuiComposerHistoryState {
+  return {
+    entries: values.map((value) => composerOf(value)),
+    browsingIndex: null,
+    draftBeforeBrowsing: null,
+    ...overrides,
+  };
+}
+
+describe("rememberSubmittedComposerValue", () => {
+  it("appends a submitted value", () => {
+    const next = rememberSubmittedComposerValue(
+      emptyHistory,
+      composerOf("hello"),
+    );
+    expect(next.entries.map((e) => e.value)).toEqual(["hello"]);
+    expect(next.browsingIndex).toBeNull();
+  });
+
+  it("skips consecutive duplicate submissions", () => {
+    const next = rememberSubmittedComposerValue(
+      historyOf(["hello"]),
+      composerOf("hello"),
+    );
+    expect(next.entries.map((e) => e.value)).toEqual(["hello"]);
+  });
+
+  it("resets browsing state when skipping a duplicate", () => {
+    const next = rememberSubmittedComposerValue(
+      historyOf(["hello"], {
+        browsingIndex: 0,
+        draftBeforeBrowsing: composerOf("draft"),
+      }),
+      composerOf("hello"),
+    );
+    expect(next.browsingIndex).toBeNull();
+    expect(next.draftBeforeBrowsing).toBeNull();
+  });
+
+  it("caps history at 200 entries", () => {
+    const full = historyOf(Array.from({ length: 200 }, (_, i) => `entry-${i}`));
+    const next = rememberSubmittedComposerValue(full, composerOf("newest"));
+    expect(next.entries).toHaveLength(200);
+    expect(next.entries[0]!.value).toBe("entry-1");
+    expect(next.entries.at(-1)!.value).toBe("newest");
+  });
+});
+
+describe("browseComposerHistory", () => {
+  it("absorbs older navigation at the oldest entry", () => {
+    const history = historyOf(["a", "b"], { browsingIndex: 0 });
+    const composer: StepCliTuiComposerState = { value: "a", cursorIndex: 0 };
+    const next = browseComposerHistory(history, composer, "older");
+    expect(next.history).toBe(history);
+    expect(next.composer).toBe(composer);
+  });
+
+  it("walks older entries and stores the draft", () => {
+    const next = browseComposerHistory(
+      historyOf(["a", "b"]),
+      composerOf("draft"),
+      "older",
+    );
+    expect(next.composer.value).toBe("b");
+    expect(next.history.browsingIndex).toBe(1);
+    expect(next.history.draftBeforeBrowsing?.value).toBe("draft");
+  });
+
+  it("restores the draft when browsing past the newest entry", () => {
+    const history = historyOf(["a"], {
+      browsingIndex: 0,
+      draftBeforeBrowsing: composerOf("draft"),
+    });
+    const next = browseComposerHistory(history, composerOf("a"), "newer");
+    expect(next.composer.value).toBe("draft");
+    expect(next.history.browsingIndex).toBeNull();
+    expect(next.history.draftBeforeBrowsing).toBeNull();
+  });
+});

--- a/src/tui/composer-state.ts
+++ b/src/tui/composer-state.ts
@@ -5,6 +5,8 @@ import type {
 
 export type StepCliTuiComposerHistoryDirection = "older" | "newer";
 
+const MAX_COMPOSER_HISTORY_ENTRIES = 200;
+
 export function applyComposerPaste(
   composer: StepCliTuiComposerState,
   text: string,
@@ -34,8 +36,15 @@ export function rememberSubmittedComposerValue(
     return detachComposerHistory(history);
   }
 
+  const lastEntry = history.entries[history.entries.length - 1];
+  if (lastEntry?.value === composer.value) {
+    return detachComposerHistory(history);
+  }
+
   return {
-    entries: [...history.entries, cloneComposerState(composer)],
+    entries: [...history.entries, cloneComposerState(composer)].slice(
+      -MAX_COMPOSER_HISTORY_ENTRIES,
+    ),
     browsingIndex: null,
     draftBeforeBrowsing: null,
   };
@@ -54,6 +63,10 @@ export function browseComposerHistory(
   }
 
   if (direction === "older") {
+    if (history.browsingIndex === 0) {
+      return { history, composer };
+    }
+
     const nextIndex =
       history.browsingIndex === null
         ? history.entries.length - 1


### PR DESCRIPTION
## Summary

This PR fixes five composer input issues in the TUI, found by auditing the keyboard handling in `src/tui/app.tsx` and `src/tui/composer-state.ts`. All fixes are minimal and confined to the input layer; no core architecture is touched.

### 1. Up/Down boundary navigation in multiline input (main fix)
Previously, when the composer contained a newline, Up/Down were passed through to the editor with no boundary handling. Now, readline-style staged navigation:
- **Up** with the cursor on the first line jumps to the **start** of the text; pressing Up again (at offset 0) browses **older history**.
- **Down** with the cursor on the last line jumps to the **end** of the text; pressing Down again (at the end) browses **newer history** / restores the draft.

This also fixes a navigation deadlock: recalling a **multiline** history entry used to make Up/Down dead (both returned early on `value.includes("\n")`), so the user could neither continue browsing history nor get back to their stashed draft — editing the entry then dropped `draftBeforeBrowsing`, losing the draft permanently.

Single-line behavior is unchanged (Up/Down still browse history immediately).

### 2. History endpoint absorption
At the oldest entry, pressing Up used to re-run `replaceComposer`, rewriting the editor text and snapping the cursor back to the entry's stored position. The key is now absorbed, symmetric with the newer-direction endpoint.

### 3. History dedup + cap
`rememberSubmittedComposerValue` appended unconditionally: consecutive identical submissions created duplicate entries (Up had to be pressed N times to cross them), and entries grew without bound for the whole session. Adjacent duplicates are now skipped and history is capped at 200 entries.

### 4. Enter autocomplete no longer drops typed arguments
Submitting `/res my-session-id` used to silently replace the whole input with `/resume ` (and `/re xxx` with `/refresh`, a different command), because the Enter autocomplete path ignored everything after the first token. Autocomplete now only triggers when the input is a bare command token; with arguments present the input is submitted as-is so unknown commands surface an error instead of eating the argument. Bare `/res` + Enter still autocompletes as before.

### 5. Slash command completion no longer erases input typed during await
`handleSubmit` cleared the composer **after** `await handleSlashCommand(...)`; anything typed while a slow command ran (`/voice` connecting, `/goal`, `/refresh`, `/theme`) was silently wiped. The clear is now guarded by a snapshot comparison, and the redundant unconditional clear inside `/goal` (which double-cleared) is removed.

## Test plan
- Added `src/tui/composer-state.test.ts` (7 tests: dedup, browsing-state reset, 200-entry cap, oldest-endpoint absorption, draft stash/restore).
- `pnpm test`: 81 files, 1155 passed.
- `pnpm exec tsc --noEmit`: clean.
- `pnpm lint`: 0 errors (8 pre-existing warnings untouched).
- `pnpm format:check` passes for all files changed here (`docs/skills/pr-review-decision.md` already fails on main, unrelated).
- Manual: multiline first/last-line Up/Down jump + staged history browse, single-line history unchanged, slash palette navigation unchanged, `/res <arg>` submit behavior.