### PR TITLE
fix(gateway): use cooked-mode readline for approval prompts on Windows

### DIFF
--- a/src/gateway/interactive-readline.test.ts
+++ b/src/gateway/interactive-readline.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  createInteractiveReadline,
+  disposeInteractiveReadline,
+  __resetInteractiveReadlineForTests,
+  __getInteractiveReadlineInvocationCountForTests,
+} from "./interactive-readline.js";
+
+describe("interactive-readline factory", () => {
+  beforeEach(() => {
+    __resetInteractiveReadlineForTests();
+  });
+
+  afterEach(() => {
+    __resetInteractiveReadlineForTests();
+    delete process.env.LOG_LEVEL;
+  });
+
+  it("returns a fresh, independent interface per call", () => {
+    const rl1 = createInteractiveReadline();
+    const rl2 = createInteractiveReadline();
+
+    expect(rl1).not.toBe(rl2);
+    expect(__getInteractiveReadlineInvocationCountForTests()).toBe(2);
+  });
+
+  it("uses terminal:false (cooked mode) to avoid Windows raw-mode issues", () => {
+    // With terminal:false, readline does NOT attach a keypress listener
+    // to stdin. We can't directly read the option from the public API,
+    // but we can assert the side effect: no keypress listener growth.
+    const before = process.stdin.listenerCount("keypress");
+
+    const rl = createInteractiveReadline();
+
+    expect(process.stdin.listenerCount("keypress")).toBe(before);
+
+    disposeInteractiveReadline(rl);
+  });
+
+  it("disposeInteractiveReadline brings keypress listener count back down", () => {
+    const before = process.stdin.listenerCount("keypress");
+
+    const rl = createInteractiveReadline();
+    disposeInteractiveReadline(rl);
+
+    expect(process.stdin.listenerCount("keypress")).toBeLessThanOrEqual(before);
+  });
+
+  it("disposeInteractiveReadline is safe to call on an already-closed interface", () => {
+    const rl = createInteractiveReadline();
+    rl.close();
+    expect(() => disposeInteractiveReadline(rl)).not.toThrow();
+  });
+
+  it("does not accumulate keypress listeners across create/dispose cycles", () => {
+    const before = process.stdin.listenerCount("keypress");
+
+    for (let i = 0; i < 5; i += 1) {
+      const rl = createInteractiveReadline();
+      disposeInteractiveReadline(rl);
+    }
+
+    expect(process.stdin.listenerCount("keypress")).toBeLessThanOrEqual(before);
+  });
+
+  it("does not throw when debug logging is enabled", () => {
+    process.env.LOG_LEVEL = "debug";
+    expect(() => {
+      const rl = createInteractiveReadline();
+      disposeInteractiveReadline(rl);
+    }).not.toThrow();
+  });
+});

--- a/src/gateway/interactive-readline.test.ts
+++ b/src/gateway/interactive-readline.test.ts
@@ -46,6 +46,26 @@ describe("interactive-readline factory", () => {
     expect(process.stdin.listenerCount("keypress")).toBeLessThanOrEqual(before);
   });
 
+  it("does not remove keypress listeners that existed before the prompt", () => {
+    const existingListener = () => undefined;
+    const leakedPromptListener = () => undefined;
+    process.stdin.on("keypress", existingListener);
+
+    try {
+      const rl = createInteractiveReadline();
+      process.stdin.on("keypress", leakedPromptListener);
+      disposeInteractiveReadline(rl);
+
+      expect(process.stdin.listeners("keypress")).toContain(existingListener);
+      expect(process.stdin.listeners("keypress")).not.toContain(
+        leakedPromptListener,
+      );
+    } finally {
+      process.stdin.removeListener("keypress", existingListener);
+      process.stdin.removeListener("keypress", leakedPromptListener);
+    }
+  });
+
   it("disposeInteractiveReadline is safe to call on an already-closed interface", () => {
     const rl = createInteractiveReadline();
     rl.close();

--- a/src/gateway/interactive-readline.ts
+++ b/src/gateway/interactive-readline.ts
@@ -1,0 +1,96 @@
+import readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import { appendStderrDevLog } from "../runtime/stderr-dev-log.js";
+
+/**
+ * Create a readline interface for one-shot prompts (tool approval, user
+ * clarification). Use `disposeInteractiveReadline` in the prompt's
+ * `finally` block to tear it down.
+ *
+ * Uses `terminal: false` deliberately. The previous `terminal: true`
+ * configuration put stdin into raw mode and attached a `keypress` listener,
+ * both of which are unreliable on Windows (ConHost / Windows Terminal):
+ *
+ *   1. `rl.close()` does not reliably remove the keypress listener, causing
+ *      listener accumulation across prompts. At the Nth prompt, each leaked
+ *      listener echoed the same keystroke, so pressing `y` once rendered as
+ *      N `y` characters.
+ *   2. Windows console focus / IME / mode-switch events leak through raw
+ *      mode as spurious empty line events, so `rl.question()` resolved with
+ *      `""` on its own — the "auto-advance" symptom where each prompt
+ *      disappeared without user input.
+ *
+ * `terminal: false` keeps stdin in cooked mode: the OS handles line editing
+ * and delivers complete lines only when the user presses Enter. No raw
+ * mode, no keypress listener, no spurious events.
+ *
+ * Trade-off: no in-line editing (backspace, arrow keys, history). For y/n
+ * approval prompts that's acceptable; users type one char + Enter.
+ */
+let promptInvocationCount = 0;
+
+function isDebugLogEnabled(): boolean {
+  const level = process.env.LOG_LEVEL;
+  return level === "debug" || level === "trace";
+}
+
+function logApprovalReadlineDebug(message: string): void {
+  if (!isDebugLogEnabled()) return;
+  void appendStderrDevLog(`[debug] event=approval-readline ${message}\n`);
+}
+
+export function createInteractiveReadline(): readline.Interface {
+  promptInvocationCount += 1;
+  logApprovalReadlineDebug(
+    `create invocation=${promptInvocationCount} terminal=false`,
+  );
+  return readline.createInterface({
+    input,
+    output,
+    terminal: false,
+  });
+}
+
+export function disposeInteractiveReadline(rl: readline.Interface): void {
+  logApprovalReadlineDebug(
+    `dispose invocation=${promptInvocationCount} keypressListeners=${input.listenerCount("keypress")}`,
+  );
+
+  try {
+    rl.close();
+  } catch {
+    // ignore — may already be closed
+  }
+
+  // Windows defensive cleanup. With `terminal: false` this is mostly
+  // belt-and-suspenders (no raw mode, no keypress listener expected), but
+  // we have observed residue in some console hosts.
+  try {
+    if (typeof input.setRawMode === "function") {
+      input.setRawMode(false);
+    }
+  } catch {
+    // ignore — stdin may already be destroyed
+  }
+
+  try {
+    input.pause();
+  } catch {
+    // ignore — stdin may already be destroyed
+  }
+
+  const keypressListeners = input.listeners("keypress") as (() => void)[];
+  for (const listener of keypressListeners) {
+    input.removeListener("keypress", listener);
+  }
+}
+
+/** Test-only: reset invocation counter between unit tests. */
+export function __resetInteractiveReadlineForTests(): void {
+  promptInvocationCount = 0;
+}
+
+/** Test-only: observe invocation count. */
+export function __getInteractiveReadlineInvocationCountForTests(): number {
+  return promptInvocationCount;
+}

--- a/src/gateway/interactive-readline.ts
+++ b/src/gateway/interactive-readline.ts
@@ -28,6 +28,10 @@ import { appendStderrDevLog } from "../runtime/stderr-dev-log.js";
  * approval prompts that's acceptable; users type one char + Enter.
  */
 let promptInvocationCount = 0;
+const keypressListenersByReadline = new WeakMap<
+  readline.Interface,
+  Function[]
+>();
 
 function isDebugLogEnabled(): boolean {
   const level = process.env.LOG_LEVEL;
@@ -41,17 +45,22 @@ function logApprovalReadlineDebug(message: string): void {
 
 export function createInteractiveReadline(): readline.Interface {
   promptInvocationCount += 1;
+  const keypressListenersBeforeCreate = input.listeners("keypress");
   logApprovalReadlineDebug(
     `create invocation=${promptInvocationCount} terminal=false`,
   );
-  return readline.createInterface({
+  const rl = readline.createInterface({
     input,
     output,
     terminal: false,
   });
+  keypressListenersByReadline.set(rl, keypressListenersBeforeCreate);
+  return rl;
 }
 
 export function disposeInteractiveReadline(rl: readline.Interface): void {
+  const keypressListenersBeforeCreate =
+    keypressListenersByReadline.get(rl) ?? [];
   logApprovalReadlineDebug(
     `dispose invocation=${promptInvocationCount} keypressListeners=${input.listenerCount("keypress")}`,
   );
@@ -59,30 +68,29 @@ export function disposeInteractiveReadline(rl: readline.Interface): void {
   try {
     rl.close();
   } catch {
-    // ignore — may already be closed
+    // Ignore: may already be closed.
   }
 
-  // Windows defensive cleanup. With `terminal: false` this is mostly
-  // belt-and-suspenders (no raw mode, no keypress listener expected), but
-  // we have observed residue in some console hosts.
-  try {
-    if (typeof input.setRawMode === "function") {
-      input.setRawMode(false);
+  // A console host can still leave a keypress listener behind. Remove only
+  // listeners added after this interface was created, never ones owned by
+  // the long-lived REPL readline interface.
+  const retainedListenerCounts = new Map<Function, number>();
+  for (const listener of keypressListenersBeforeCreate) {
+    retainedListenerCounts.set(
+      listener,
+      (retainedListenerCounts.get(listener) ?? 0) + 1,
+    );
+  }
+  for (const listener of input.listeners("keypress")) {
+    const retainedCount = retainedListenerCounts.get(listener) ?? 0;
+    if (retainedCount > 0) {
+      retainedListenerCounts.set(listener, retainedCount - 1);
+      continue;
     }
-  } catch {
-    // ignore — stdin may already be destroyed
-  }
-
-  try {
-    input.pause();
-  } catch {
-    // ignore — stdin may already be destroyed
-  }
-
-  const keypressListeners = input.listeners("keypress") as (() => void)[];
-  for (const listener of keypressListeners) {
     input.removeListener("keypress", listener);
   }
+
+  keypressListenersByReadline.delete(rl);
 }
 
 /** Test-only: reset invocation counter between unit tests. */

--- a/src/gateway/runtime.ts
+++ b/src/gateway/runtime.ts
@@ -115,6 +115,10 @@ import {
   type StepCliInteractiveUi,
   type StepCliInteractiveUiFactory,
 } from "./interactive-ui.js";
+import {
+  createInteractiveReadline,
+  disposeInteractiveReadline,
+} from "./interactive-readline.js";
 import { createFilesystemAgentRunArtifactStore } from "./artifacts/run-artifact-store.js";
 import { FilesystemConversationTranscriptStore } from "./memory/filesystem-conversation-transcript-store.js";
 import { FilesystemFreshAttemptProgressStore } from "./memory/filesystem-fresh-attempt-progress-store.js";
@@ -4606,11 +4610,10 @@ async function promptForToolApproval(
       : "deny";
   }
 
-  const rl = readline.createInterface({
-    input,
-    output,
-    terminal: true,
-  });
+  // Per-call readline in cooked mode (terminal:false). See
+  // `interactive-readline.ts` for why `terminal:true` is unreliable on
+  // Windows (listener leak + spurious empty line events).
+  const rl = createInteractiveReadline();
 
   const preview =
     request.rawArgs.length > 240
@@ -4692,7 +4695,7 @@ async function promptForToolApproval(
       output.write(`Unrecognized decision: ${answer}. Type '?' for help.\n`);
     }
   } finally {
-    rl.close();
+    disposeInteractiveReadline(rl);
   }
 }
 
@@ -4708,11 +4711,8 @@ async function promptForUserClarification(
     };
   }
 
-  const rl = readline.createInterface({
-    input,
-    output,
-    terminal: true,
-  });
+  // Per-call readline in cooked mode. See `interactive-readline.ts`.
+  const rl = createInteractiveReadline();
 
   const options = Array.isArray(request.options) ? request.options : [];
   const helpLines = buildClarificationHelpLines(request);
@@ -4779,7 +4779,7 @@ async function promptForUserClarification(
       output.write(`${parsed.message}\n`);
     }
   } finally {
-    rl.close();
+    disposeInteractiveReadline(rl);
   }
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,6 +76,7 @@ export default defineConfig({
         "src/bootstrap/config/defaults.ts",
         "src/commands/option-parsers.ts",
         "src/gateway/storage/layout.ts",
+        "src/gateway/interactive-readline.ts",
         "src/gateway/verifier.ts",
         "src/runtime/runtime-config.ts",
         "src/runtime/runtime-utils.ts",


### PR DESCRIPTION
## 关联 Issue

Closes #76

## 变更类型

- [ ] feat 新功能
- [x] fix bug 修复
- [ ] docs 文档
- [ ] refactor 重构（无行为变更）
- [ ] test 仅测试
- [ ] chore 构建 / 脚手架 / CI
- [ ] perf 性能优化

## 影响范围

- [ ] 改动了 `packages/protocol/`（跨边界协议，需要同步 SDK）
- [ ] 改动了 `packages/core/` 的公开 API
- [x] 改动了 `src/gateway/`（session authority 行为变更）
- [ ] 改动了分层依赖（同步更新了 `AGENTS.md` 与 `.dependency-cruiser.cjs`）
- [ ] 仅 docs / 注释 / 测试

## 变更说明（why，而非 what）

Windows console 下，`terminal: true` 创建的 readline 接口在 `rl.close()` 时无法可靠移除 stdin 上的 `keypress` listener。每次 `promptForToolApproval` / `promptForUserClarification` 进出都给 stdin 累加一个泄漏的 listener。到第 N 个 prompt 时，累积的 N 个 listener 既会从 Windows focus / IME / 终端模式切换事件合成出空行提交（`rl.question()` 提前 resolve 成 `""`，被解释为 deny，agent-loop 顺序推进到下一个 tool call —— 即「30 秒静默后 prompt 自动跳过」），又会把单次 `y` 通过每个 listener 的 `_ttyWrite` 各 echo 一次（终端显示 `yyy`）。`yy`/`yyy` 无法匹配决策解析，会话死锁。

详见 #76 的根因分析。

**关键决策**：把 readline 接口从 `terminal: true` 切到 `terminal: false`（cooked mode）。OS 接管行编辑，只在用户按 Enter 时交付完整一行 —— 没有 raw mode、没有 keypress listener、没有伪空行事件。两个症状从源头一起消除。

**接受的折衷**：prompt 内失去行内编辑（退格 / 方向键 / 历史）。对 y/n 审批场景可接受，用户只需输入一个字符 + Enter。

**实现结构**：抽出 `src/gateway/interactive-readline.ts` 作为工厂（per-call 创建 + dispose），两个 prompt 函数在 `try/finally` 里使用。工厂在创建时快照已有的 `keypress` listener；dispose 只清理此后新增的差集，不再调用 `input.pause()` 或 `setRawMode(false)`，因此不会影响主 REPL 的长驻 readline。

## 测试计划

- [x] 单测：`src/gateway/interactive-readline.test.ts` 共 7 个用例，覆盖每次调用返回独立 interface、`terminal: false` 不增长 keypress listener、dispose 安全可重入、循环 create/dispose 不累积 listener、debug 日志开启时不抛错，以及 dispose 不影响既存 listener。`pnpm vitest run src/gateway/interactive-readline.test.ts` 全绿。
- [x] 集成：不涉及（readline 改动属于交互层，无对应 integration 套件）。
- [x] 手工验证（Windows 11 10.0.26200，Windows Terminal）：
  - `pnpm step "list all .md files in the current directory"` —— 修复前 ~30s 静默后会自动刷出下一条 prompt，且按一次 `y` 显示 `yyy`；修复后**只出现一条** prompt，静默 30s+ 不自动跳过，按一次 `y` + Enter 单字符显示并正常推进到下一个 tool call。
  - `pnpm step`（无参数，REPL 模式）—— 主输入框与 approval 流程互不干扰。
- [x] `vitest.config.ts` 的 `coverage.include` 已加入 `src/gateway/interactive-readline.ts`。

## 自检清单

- [x] 本地 `pnpm check` 已通过（test / lint / dep-guard / deadcode / tsc / format）
- [x] 新加文件配套加了 `.test.ts`
- [x] 平台相关代码用了 `vi.skipIf` / `describe.runIf`，未硬编码 platform 判断 —— 本改动不引入新的平台分支，行为对所有平台一致（只是 Windows 上更需要）
- [x] 新增被覆盖统计的模块已同步加入 `vitest.config.ts` 的 `coverage.include`
- [x] 不包含二进制、构建产物、密钥
- [x] 未使用 `--no-verify` 绕过钩子
