### PR TITLE
fix: code quality, resource cleanup, and duplicate code extraction

### DIFF
--- a/extensions/realtime-voice/src/bridge/abort-race.test.ts
+++ b/extensions/realtime-voice/src/bridge/abort-race.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { raceWithAbort } from "./abort-race.js";
+
+describe("raceWithAbort", () => {
+  it("removes the abort listener when work completes normally", async () => {
+    const controller = new AbortController();
+    const removeEventListener = vi.spyOn(
+      controller.signal,
+      "removeEventListener",
+    );
+
+    await expect(
+      raceWithAbort(
+        controller.signal,
+        Promise.resolve("done"),
+        () => "aborted",
+      ),
+    ).resolves.toBe("done");
+
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+  });
+
+  it("returns the abort result when the signal aborts first", async () => {
+    const controller = new AbortController();
+    const work = new Promise<string>(() => {});
+    const result = raceWithAbort(controller.signal, work, () => "aborted");
+
+    controller.abort();
+
+    await expect(result).resolves.toBe("aborted");
+  });
+});

--- a/extensions/realtime-voice/src/bridge/abort-race.ts
+++ b/extensions/realtime-voice/src/bridge/abort-race.ts
@@ -1,0 +1,21 @@
+export function raceWithAbort<T>(
+  signal: AbortSignal,
+  work: Promise<T>,
+  onAbort: () => T,
+): Promise<T> {
+  let removeListener: () => void = () => {};
+  const aborted = new Promise<T>((resolve) => {
+    const listener = () => {
+      removeListener();
+      resolve(onAbort());
+    };
+    if (signal.aborted) {
+      listener();
+      return;
+    }
+    signal.addEventListener("abort", listener, { once: true });
+    removeListener = () => signal.removeEventListener("abort", listener);
+  });
+
+  return Promise.race([work, aborted]).finally(removeListener);
+}

--- a/extensions/realtime-voice/src/bridge/coding-bridge.ts
+++ b/extensions/realtime-voice/src/bridge/coding-bridge.ts
@@ -12,6 +12,7 @@ import {
   type TaskFinalSummary,
   type TaskSnapshot,
 } from "@step-cli/realtime";
+import { raceWithAbort } from "./abort-race.js";
 
 const log = logger.child({ component: "coding-bridge" });
 
@@ -129,21 +130,12 @@ export class CodingBridge {
         // throw on abort is not reliable (the subprocess can linger), and a
         // run() that never settles would leave currentTask stuck forever →
         // cancel appears to do nothing and no new task can be started.
-        const aborted = new Promise<TaskFinalSummary>((resolve) => {
-          const onAbort = () =>
-            resolve({
-              status: "interrupted",
-              summary: "任务已取消",
-              detail: makeDetail(progress) as unknown as Record<
-                string,
-                unknown
-              >,
-            });
-          if (ac.signal.aborted) onAbort();
-          else ac.signal.addEventListener("abort", onAbort, { once: true });
-        });
         const work = this.runAgent(task, shouldResume, ac, progress, emit);
-        return Promise.race([work, aborted]);
+        return raceWithAbort(ac.signal, work, () => ({
+          status: "interrupted",
+          summary: "任务已取消",
+          detail: makeDetail(progress) as unknown as Record<string, unknown>,
+        }));
       },
     });
   }


### PR DESCRIPTION
## Summary

Ensures the realtime coding bridge removes its abort listener whether a task completes normally or is interrupted.

## Changes

- Extracts `raceWithAbort()` to manage work-versus-abort races.
- Removes the abort listener after either race outcome, including normal task completion.
- Adds focused tests for normal-completion cleanup and abort-first behavior.

## Verification

- `pnpm check` ✅
- 1525 passed, 8 skipped
- Lint has no errors; remaining warnings are pre-existing on current `main`.

Closes #93