### PR TITLE
fix(core): actionable tool-failure feedback to break agent retry loops

### DIFF
--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import type { ChatCompletionClient } from "../model-client.js";
 import { isUnlimitedMaxSteps } from "../max-steps.js";
 import type {
@@ -52,6 +52,7 @@ import {
   type AgentWorkspaceMode,
 } from "./harness-context.js";
 import { AgentStateMachine, type AgentStateSnapshot } from "./state-machine.js";
+import { createToolCallFingerprint } from "./tool-fingerprint.js";
 
 export interface AgentLoopOptions {
   model: string;
@@ -1200,7 +1201,7 @@ function blockedRepeatedToolCallResult(
     summary: `Suppressed repeated tool call '${toolName}' after ${limit} identical attempts`,
     error: {
       code: "REPEATED_TOOL_CALL",
-      message: `Attempt ${attempts} exceeded repeatedToolCallLimit=${limit}. Adjust arguments or produce a final response.`,
+      message: `Attempt ${attempts} exceeded repeatedToolCallLimit=${limit}. This call keeps being suppressed even when only numeric arguments change (e.g. a larger timeout). Diagnose why the identical call keeps failing, switch to a different approach, or produce a final response.`,
     },
     data: {
       toolName,
@@ -1258,21 +1259,6 @@ function toRunMetadata(
     memoryMode: context?.executionProfile.memoryMode,
     priority: context?.executionProfile.priority,
   };
-}
-
-function createToolCallFingerprint(toolName: string, rawArgs: string): string {
-  const normalizedArgs = normalizeToolArguments(rawArgs);
-  const hash = createHash("sha1").update(normalizedArgs).digest("hex");
-  return `${toolName}:${hash}`;
-}
-
-function normalizeToolArguments(rawArgs: string): string {
-  try {
-    const parsed = JSON.parse(rawArgs) as unknown;
-    return stableStringify(parsed);
-  } catch {
-    return rawArgs.replace(/\s+/g, " ").trim();
-  }
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/core/src/agent/tool-fingerprint.test.ts
+++ b/packages/core/src/agent/tool-fingerprint.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  createToolCallFingerprint,
+  normalizeToolArguments,
+} from "./tool-fingerprint.js";
+
+describe("createToolCallFingerprint", () => {
+  it("collapses runaway numeric escalation into the same fingerprint", () => {
+    const base = { command: "cat missing.txt", timeout_ms: 20_000_000_000 };
+    const second = {
+      command: "cat missing.txt",
+      timeout_ms: 2.4e37,
+    };
+    const third = { timeout_ms: 3.6e76, command: "cat missing.txt" };
+    expect(createToolCallFingerprint("exec", JSON.stringify(base))).toBe(
+      createToolCallFingerprint("exec", JSON.stringify(second)),
+    );
+    expect(createToolCallFingerprint("exec", JSON.stringify(base))).toBe(
+      createToolCallFingerprint("exec", JSON.stringify(third)),
+    );
+  });
+
+  it("keeps distinct legitimate calls distinct", () => {
+    const first = { path: "a.txt", offset: 600_000 };
+    const second = { path: "a.txt", offset: 900_000 };
+    expect(
+      createToolCallFingerprint("read_file", JSON.stringify(first)),
+    ).not.toBe(createToolCallFingerprint("read_file", JSON.stringify(second)));
+  });
+
+  it("still distinguishes different commands with identical huge timeouts", () => {
+    const first = { command: "ls", timeout_ms: 2e10 };
+    const second = { command: "pwd", timeout_ms: 5e11 };
+    expect(createToolCallFingerprint("exec", JSON.stringify(first))).not.toBe(
+      createToolCallFingerprint("exec", JSON.stringify(second)),
+    );
+  });
+
+  it("includes the tool name in the fingerprint", () => {
+    const args = JSON.stringify({ path: "a.txt" });
+    expect(createToolCallFingerprint("read_file", args)).not.toBe(
+      createToolCallFingerprint("edit_file", args),
+    );
+  });
+});
+
+describe("normalizeToolArguments", () => {
+  it("replaces huge finite numbers with a placeholder, key order independent", () => {
+    expect(normalizeToolArguments('{"b":2.4e37,"a":1}')).toBe(
+      normalizeToolArguments('{"a":1,"b":9.9e50}'),
+    );
+    expect(normalizeToolArguments('{"timeout_ms":2e10}')).toContain(
+      "__HUGE_NUMBER__",
+    );
+  });
+
+  it("keeps small and boundary numbers intact", () => {
+    expect(normalizeToolArguments('{"timeout_ms":600000,"n":-1.5}')).toBe(
+      '{"n":-1.5,"timeout_ms":600000}',
+    );
+    expect(normalizeToolArguments('{"v":1000000000}')).toBe('{"v":1000000000}');
+    expect(normalizeToolArguments('{"v":1000000001}')).toContain(
+      "__HUGE_NUMBER__",
+    );
+  });
+
+  it("normalizes numbers nested in arrays and objects", () => {
+    const normalized = normalizeToolArguments(
+      '{"rows":[{"offset":1e12,"limit":10}]}',
+    );
+    expect(normalized).toContain("__HUGE_NUMBER__");
+    expect(normalized).toContain('"limit":10');
+  });
+
+  it("falls back to whitespace collapsing for non-JSON arguments", () => {
+    expect(normalizeToolArguments("  run   tests  ")).toBe("run tests");
+  });
+});

--- a/packages/core/src/agent/tool-fingerprint.ts
+++ b/packages/core/src/agent/tool-fingerprint.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+
+// Numeric arguments above this threshold collapse to a single placeholder in
+// the fingerprint, so runaway escalation loops (e.g. timeout_ms 2e10 -> 2e37 ->
+// 2e76 after each failure) count as repeated calls instead of fresh ones.
+// Legitimate numeric arguments (timeouts, offsets, limits) stay far below it.
+const HUGE_NUMBER_THRESHOLD = 1_000_000_000;
+const HUGE_NUMBER_PLACEHOLDER = "__HUGE_NUMBER__";
+
+export function createToolCallFingerprint(
+  toolName: string,
+  rawArgs: string,
+): string {
+  const normalizedArgs = normalizeToolArguments(rawArgs);
+  const hash = createHash("sha1").update(normalizedArgs).digest("hex");
+  return `${toolName}:${hash}`;
+}
+
+export function normalizeToolArguments(rawArgs: string): string {
+  try {
+    const parsed = JSON.parse(rawArgs) as unknown;
+    return stableStringify(normalizeHugeNumbers(parsed));
+  } catch {
+    return rawArgs.replace(/\s+/g, " ").trim();
+  }
+}
+
+function normalizeHugeNumbers(value: unknown): unknown {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && Math.abs(value) > HUGE_NUMBER_THRESHOLD
+      ? HUGE_NUMBER_PLACEHOLDER
+      : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeHugeNumbers(entry));
+  }
+  if (value && typeof value === "object") {
+    const normalized: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      normalized[key] = normalizeHugeNumbers(child);
+    }
+    return normalized;
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortRecursively(value));
+}
+
+function sortRecursively(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sortRecursively(entry));
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(
+      ([left], [right]) => left.localeCompare(right),
+    );
+    const sorted: Record<string, unknown> = {};
+    for (const [key, child] of entries) {
+      sorted[key] = sortRecursively(child);
+    }
+    return sorted;
+  }
+
+  return value;
+}

--- a/packages/core/src/tools/code-mode/service.test.ts
+++ b/packages/core/src/tools/code-mode/service.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderCellResult,
+  type CellStatus,
+  type NestedToolCall,
+  type RunningCell,
+} from "./service.js";
+
+function makeCall(overrides?: Partial<NestedToolCall>): NestedToolCall {
+  return {
+    toolName: "run_command",
+    identifier: "run_command",
+    ok: true,
+    summary: "Command completed",
+    ...overrides,
+  };
+}
+
+function makeCell(overrides?: Partial<RunningCell>): RunningCell {
+  return {
+    id: "cell-test-1",
+    startedAt: Date.now(),
+    code: "const r = await tools.run_command({command: 'ls'});",
+    abortController: new AbortController(),
+    consoleLines: [],
+    status: "completed",
+    nestedCalls: [],
+    completion: Promise.resolve(),
+    ...overrides,
+  };
+}
+
+function render(status: CellStatus, cell: RunningCell) {
+  return renderCellResult({ cell, status, commandOutputLimit: 8000 });
+}
+
+describe("renderCellResult structured feedback", () => {
+  it("reports all-successful completions without failure noise", () => {
+    const cell = makeCell({
+      nestedCalls: [makeCall(), makeCall({ toolName: "read_file" })],
+    });
+    const result = render("completed", cell);
+    expect(result.ok).toBe(true);
+    expect(result.summary).toBe("Script completed · 2 tool calls");
+    expect(result.data?.failedToolCalls).toBe(0);
+    expect(result.content).not.toContain("failed");
+  });
+
+  it("surfaces per-call failure reasons that were previously hidden", () => {
+    const cell = makeCell({
+      nestedCalls: [
+        makeCall(),
+        makeCall({
+          ok: false,
+          summary:
+            "Command failed with exit code 1: cat: missing.txt: No such file",
+          inputHint: "cat missing.txt",
+        }),
+      ],
+    });
+    const result = render("completed", cell);
+    expect(result.ok).toBe(true);
+    expect(result.summary).toBe(
+      "Script completed · 2 tool calls, 1 failed tool call",
+    );
+    expect(result.data?.failedToolCalls).toBe(1);
+    expect(result.content).toContain(
+      "✗ run_command cat missing.txt — Command failed with exit code 1",
+    );
+  });
+
+  it("disambiguates no-return diagnostics when tool calls failed", () => {
+    const cell = makeCell({
+      nestedCalls: [
+        makeCall({ ok: false, summary: "Command failed with exit code 2" }),
+      ],
+    });
+    const result = render("completed", cell);
+    expect(result.content).toContain("tool-level failures, not timeouts");
+    expect(result.content).toContain(
+      "Script completed without a returned result.",
+    );
+  });
+
+  it("keeps the plain no-return diagnostic when nothing failed", () => {
+    const cell = makeCell();
+    const result = render("completed", cell);
+    expect(result.content).toContain(
+      "Script completed without a returned result.",
+    );
+    expect(result.content).not.toContain("not timeouts");
+  });
+
+  it("shows grouped failure reasons when calls exceed the per-call limit", () => {
+    const calls: NestedToolCall[] = [];
+    for (let index = 0; index < 6; index += 1) {
+      calls.push(makeCall({ inputHint: `attempt-${index}` }));
+    }
+    for (let index = 0; index < 4; index += 1) {
+      calls.push(
+        makeCall({
+          ok: false,
+          summary: "Command failed with exit code 1",
+          inputHint: `failing-${index}`,
+        }),
+      );
+    }
+    const cell = makeCell({ nestedCalls: calls });
+    const result = render("completed", cell);
+    expect(result.content).toMatch(/6\/10 run_command ×10/);
+    expect(result.content).toContain("✗ Command failed with exit code 1");
+  });
+
+  it("keeps failed script status reporting intact", () => {
+    const cell = makeCell({ errorText: "TypeError: boom" });
+    const result = render("failed", cell);
+    expect(result.ok).toBe(false);
+    expect(result.summary).toBe("Script failed");
+    expect(result.content).toContain("TypeError: boom");
+  });
+});

--- a/packages/core/src/tools/code-mode/service.ts
+++ b/packages/core/src/tools/code-mode/service.ts
@@ -17,9 +17,9 @@ const MAX_RENDER_CHARS = 120_000;
 const MIN_RENDER_CHARS = 200;
 const RUNTIME_BOOT_TIMEOUT_MS = 1_000;
 
-type CellStatus = "running" | "completed" | "failed" | "terminated";
+export type CellStatus = "running" | "completed" | "failed" | "terminated";
 
-interface NestedToolCall {
+export interface NestedToolCall {
   toolName: string;
   identifier: string;
   ok: boolean;
@@ -59,7 +59,7 @@ interface CodeModeSandbox {
   TextDecoder: typeof TextDecoder;
 }
 
-interface RunningCell {
+export interface RunningCell {
   id: string;
   startedAt: number;
   code: string;
@@ -547,16 +547,24 @@ function createAbortError(signal?: AbortSignal): Error {
   );
 }
 
-function renderCellResult(input: {
+export function renderCellResult(input: {
   cell: RunningCell;
   status: CellStatus;
   commandOutputLimit: number;
   maxTokens?: number;
-}): ToolExecutionResult {
+}): ToolExecutionResult<{
+  cell_id: string;
+  status: CellStatus;
+  running: boolean;
+  failedToolCalls: number;
+}> {
   const prefixLines: string[] = [];
   const tailLines: string[] = [];
   let summary = "";
   let ok = true;
+  const failedToolCalls = input.cell.nestedCalls.filter(
+    (call) => !call.ok,
+  ).length;
 
   switch (input.status) {
     case "running": {
@@ -570,9 +578,18 @@ function renderCellResult(input: {
     }
     case "completed": {
       const toolCount = input.cell.nestedCalls.length;
+      const parts: string[] = [];
+      if (toolCount > 0) {
+        parts.push(`${toolCount} tool call${toolCount === 1 ? "" : "s"}`);
+      }
+      if (failedToolCalls > 0) {
+        parts.push(
+          `${failedToolCalls} failed tool call${failedToolCalls === 1 ? "" : "s"}`,
+        );
+      }
       summary =
-        toolCount > 0
-          ? `Script completed · ${toolCount} tool call${toolCount === 1 ? "" : "s"}`
+        parts.length > 0
+          ? `Script completed · ${parts.join(", ")}`
           : "Script completed";
       break;
     }
@@ -608,7 +625,8 @@ function renderCellResult(input: {
         const hintStr = hint
           ? ` ${hint.length > 60 ? hint.slice(0, 57) + "..." : hint}`
           : "";
-        tailLines.push(`${mark} ${call.toolName}${hintStr}`);
+        const reason = !call.ok && call.summary ? ` — ${call.summary}` : "";
+        tailLines.push(`${mark} ${call.toolName}${hintStr}${reason}`);
       }
     } else {
       // Many calls: group by tool, show count and key details
@@ -642,6 +660,14 @@ function renderCellResult(input: {
           const short = h.length > 68 ? h.slice(0, 65) + "..." : h;
           tailLines.push(`  ${short}`);
         }
+        if (info.ok < info.count) {
+          const firstFailed = calls.find(
+            (call) => call.toolName === name && !call.ok,
+          );
+          if (firstFailed?.summary) {
+            tailLines.push(`  ✗ ${firstFailed.summary}`);
+          }
+        }
         if (info.hints.length < info.count && info.count > info.hints.length) {
           const more = info.count - info.hints.length;
           if (more > 0 && info.hints.length > 0)
@@ -668,6 +694,11 @@ function renderCellResult(input: {
   if (input.status === "completed" && input.cell.result === undefined) {
     tailLines.push("Diagnostic:");
     tailLines.push("Script completed without a returned result.");
+    if (failedToolCalls > 0) {
+      tailLines.push(
+        `${failedToolCalls} tool call(s) above failed — the script itself ran to completion, so these are tool-level failures, not timeouts. Read the ✗ lines for the actual error before retrying.`,
+      );
+    }
     tailLines.push(
       "Return the final value directly from the top-level exec body if you need it in the model context.",
     );
@@ -746,6 +777,7 @@ function renderCellResult(input: {
       cell_id: input.cell.id,
       status: input.status,
       running: input.status === "running",
+      failedToolCalls,
     },
   };
 }

--- a/packages/core/src/tools/runtime-unknown-tool.test.ts
+++ b/packages/core/src/tools/runtime-unknown-tool.test.ts
@@ -1,5 +1,57 @@
 import { describe, it, expect } from "vitest";
-import { formatUnknownToolMessage } from "./runtime.js";
+import { ToolRuntime, formatUnknownToolMessage } from "./runtime.js";
+import type { ToolExecutionContext, ToolSpec } from "@step-cli/protocol";
+
+function makeSpec(name: string): ToolSpec {
+  return {
+    definition: {
+      type: "function",
+      function: {
+        name,
+        description: `${name} test tool`,
+        parameters: { type: "object", properties: {} },
+      },
+    },
+    security: { risk: "read" },
+    parseArgs: () => ({}),
+    execute: async () => ({ ok: true, summary: "ok" }),
+  };
+}
+
+const execContext: ToolExecutionContext = {
+  workspaceRoot: "/",
+  commandTimeoutMs: 1_000,
+  commandOutputLimit: 1_000,
+};
+
+describe("ToolRuntime unknown tool errors", () => {
+  it("routes a hallucinated top-level call to its nested code-mode binding", async () => {
+    const runtime = new ToolRuntime(
+      [makeSpec("exec"), makeSpec("wait"), makeSpec("read_file")],
+      execContext,
+    );
+    const result = await runtime.executeTool("read_file", "{}");
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("UNKNOWN_TOOL");
+    expect(result.error?.message).toContain("Available tools: exec, wait.");
+    expect(result.error?.message).toContain(
+      "call exec and use tools.read_file(...) inside it",
+    );
+  });
+
+  it("reports unknown nested calls with the real nested tool list", async () => {
+    const runtime = new ToolRuntime(
+      [makeSpec("exec"), makeSpec("wait"), makeSpec("read_file")],
+      execContext,
+    );
+    const result = await runtime.executeNestedTool("readfile", "{}");
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain(
+      "Available nested tools: read_file.",
+    );
+    expect(result.error?.message).toContain("Did you mean 'read_file'?");
+  });
+});
 
 describe("formatUnknownToolMessage", () => {
   const codeModeTools = {

--- a/packages/core/src/tools/runtime-unknown-tool.test.ts
+++ b/packages/core/src/tools/runtime-unknown-tool.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { formatUnknownToolMessage } from "./runtime.js";
+
+describe("formatUnknownToolMessage", () => {
+  const codeModeTools = {
+    name: "read_file",
+    scope: "top-level" as const,
+    availableTools: ["exec", "wait"],
+    nestedToolBindings: [
+      "apply_patch",
+      "edit_file",
+      "list_directory",
+      "read_file",
+      "run_command",
+    ],
+  };
+
+  it("routes a hallucinated top-level call to its nested code-mode binding", () => {
+    const message = formatUnknownToolMessage(codeModeTools);
+    expect(message).toContain("Tool 'read_file' is not registered.");
+    expect(message).toContain("Available tools: exec, wait.");
+    expect(message).toContain(
+      "call exec and use tools.read_file(...) inside it",
+    );
+    expect(message).not.toContain("Nested bindings:");
+  });
+
+  it("lists all nested bindings when no close match exists", () => {
+    const message = formatUnknownToolMessage({
+      ...codeModeTools,
+      name: "open_browser",
+    });
+    expect(message).toContain("Tool 'open_browser' is not registered.");
+    expect(message).toContain("Nested bindings: apply_patch, edit_file");
+    expect(message).toContain("run_command.");
+    expect(message).toContain("Do not retry this top-level call.");
+  });
+
+  it("suggests the closest direct tool when code mode is off", () => {
+    const message = formatUnknownToolMessage({
+      name: "raed_file",
+      scope: "top-level",
+      availableTools: ["read_file", "edit_file", "run_command"],
+    });
+    expect(message).toContain("Available tools: read_file, edit_file");
+    expect(message).toContain("Did you mean 'read_file'?");
+    expect(message).not.toContain("Code Mode");
+  });
+
+  it("does not suggest garbage names", () => {
+    const message = formatUnknownToolMessage({
+      name: "xkjzzz",
+      scope: "top-level",
+      availableTools: ["read_file", "run_command"],
+    });
+    expect(message).not.toContain("Did you mean");
+  });
+
+  it("uses nested-tool phrasing for calls from inside the sandbox", () => {
+    const message = formatUnknownToolMessage({
+      name: "readfile",
+      scope: "nested",
+      availableTools: ["read_file", "edit_file"],
+    });
+    expect(message).toContain("Available nested tools: read_file, edit_file.");
+    expect(message).toContain("Did you mean 'read_file'?");
+    expect(message).not.toContain("Code Mode:");
+  });
+
+  it("handles an empty tool list", () => {
+    const message = formatUnknownToolMessage({
+      name: "read_file",
+      scope: "top-level",
+      availableTools: [],
+    });
+    expect(message).toBe("Tool 'read_file' is not registered.");
+  });
+
+  it("caps very long tool lists", () => {
+    const many = Array.from({ length: 30 }, (_, index) => `tool_${index}`);
+    const message = formatUnknownToolMessage({
+      name: "nope",
+      scope: "top-level",
+      availableTools: many,
+    });
+    expect(message).toContain("tool_23 (+6 more).");
+    expect(message).not.toContain("tool_24");
+  });
+});

--- a/packages/core/src/tools/runtime.ts
+++ b/packages/core/src/tools/runtime.ts
@@ -275,6 +275,39 @@ export class ToolRuntime implements ToolRuntimeApi {
     this.baseSignal = signal;
   }
 
+  private unknownToolError(
+    name: string,
+    scope: "top-level" | "nested",
+  ): ToolExecutionResult {
+    if (scope === "nested") {
+      const nestedTools = this.codeModeEnabled
+        ? this.getCodeModeToolBindings().map((binding) => binding.identifier)
+        : [...this.nestedSpecsByName.keys()];
+      return unknownToolResult(name, {
+        scope,
+        availableTools: nestedTools,
+      });
+    }
+
+    if (this.codeModeEnabled) {
+      return unknownToolResult(name, {
+        scope,
+        availableTools: this.listToolNames(),
+        nestedToolBindings: this.getCodeModeToolBindings().map(
+          (binding) => binding.identifier,
+        ),
+      });
+    }
+
+    return unknownToolResult(name, {
+      scope,
+      availableTools: [
+        ...this.listToolNames(),
+        ...this.nestedSpecsByName.keys(),
+      ],
+    });
+  }
+
   async executeTool(
     name: string,
     rawArgs: string,
@@ -284,7 +317,7 @@ export class ToolRuntime implements ToolRuntimeApi {
     if (internalName) {
       const visible = this.visibleSpecsByName.get(name);
       if (!visible) {
-        return unknownToolResult(name);
+        return this.unknownToolError(name, "top-level");
       }
 
       return this.dispatchTool({
@@ -301,12 +334,12 @@ export class ToolRuntime implements ToolRuntimeApi {
     }
 
     if (this.codeModeEnabled) {
-      return unknownToolResult(name);
+      return this.unknownToolError(name, "top-level");
     }
 
     const rawSpec = this.nestedSpecsByName.get(name);
     if (!rawSpec) {
-      return unknownToolResult(name);
+      return this.unknownToolError(name, "top-level");
     }
 
     return this.dispatchTool({
@@ -330,12 +363,12 @@ export class ToolRuntime implements ToolRuntimeApi {
       ? name
       : this.nestedInternalNameByExternalName.get(name);
     if (!internalName) {
-      return unknownToolResult(name);
+      return this.unknownToolError(name, "nested");
     }
 
     const spec = this.nestedSpecsByName.get(internalName);
     if (!spec) {
-      return unknownToolResult(name);
+      return this.unknownToolError(name, "nested");
     }
 
     return this.dispatchTool({
@@ -770,15 +803,127 @@ function getExecutionErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function unknownToolResult(name: string): ToolExecutionResult {
+export function formatUnknownToolMessage(input: {
+  name: string;
+  scope: "top-level" | "nested";
+  availableTools: string[];
+  nestedToolBindings?: string[];
+}): string {
+  const { name, scope, nestedToolBindings } = input;
+  const available = dedupeNames(input.availableTools).filter(
+    (item) => item !== name,
+  );
+  const bindings = nestedToolBindings ? dedupeNames(nestedToolBindings) : [];
+  const nestedSuggestion =
+    scope === "top-level" && bindings.length > 0
+      ? bestToolSuggestion(name, bindings)
+      : undefined;
+  const directSuggestion =
+    available.length > 0 ? bestToolSuggestion(name, available) : undefined;
+
+  const parts: string[] = [`Tool '${name}' is not registered.`];
+  if (available.length > 0) {
+    const label =
+      scope === "nested" ? "Available nested tools" : "Available tools";
+    parts.push(`${label}: ${formatToolNameList(available)}`);
+  }
+  if (nestedSuggestion) {
+    parts.push(
+      `Code Mode: nested tool '${nestedSuggestion}' exists — call exec and use tools.${nestedSuggestion}(...) inside it instead of retrying this top-level call.`,
+    );
+  } else if (scope === "top-level" && bindings.length > 0) {
+    parts.push(
+      `Code Mode: nested tools are callable only inside exec as tools.<name>(...). Nested bindings: ${formatToolNameList(bindings)} Do not retry this top-level call.`,
+    );
+  }
+  if (!nestedSuggestion && directSuggestion) {
+    parts.push(`Did you mean '${directSuggestion}'?`);
+  }
+  return parts.join(" ");
+}
+
+function unknownToolResult(
+  name: string,
+  hints: {
+    scope: "top-level" | "nested";
+    availableTools: string[];
+    nestedToolBindings?: string[];
+  },
+): ToolExecutionResult {
   return {
     ok: false,
     summary: `Unknown tool: ${name}`,
     error: {
       code: "UNKNOWN_TOOL",
-      message: `Tool '${name}' is not registered`,
+      message: formatUnknownToolMessage({ name, ...hints }),
     },
   };
+}
+
+function bestToolSuggestion(
+  name: string,
+  candidates: string[],
+): string | undefined {
+  let nearest: { name: string; distance: number } | undefined;
+  for (const candidate of candidates) {
+    const distance = levenshtein(name.toLowerCase(), candidate.toLowerCase());
+    if (distance <= 2 && (!nearest || distance < nearest.distance)) {
+      nearest = { name: candidate, distance };
+    }
+  }
+  if (nearest) {
+    return nearest.name;
+  }
+
+  let best: { name: string; score: number } | undefined;
+  for (const candidate of candidates) {
+    const score = scoreFuzzyMatch(name, [{ text: candidate, weight: 1 }]);
+    if (score >= 60 && (!best || score > best.score)) {
+      best = { name: candidate, score };
+    }
+  }
+  return best?.name;
+}
+
+function levenshtein(left: string, right: string): number {
+  if (left === right) {
+    return 0;
+  }
+  if (left.length === 0) {
+    return right.length;
+  }
+  if (right.length === 0) {
+    return left.length;
+  }
+
+  let previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      const substitution =
+        previous[rightIndex - 1] +
+        (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1);
+      current[rightIndex] = Math.min(
+        previous[rightIndex] + 1,
+        current[rightIndex - 1] + 1,
+        substitution,
+      );
+    }
+    previous = current;
+  }
+  return previous[right.length];
+}
+
+function dedupeNames(items: string[]): string[] {
+  return [...new Set(items.map((item) => item.trim()).filter(Boolean))];
+}
+
+function formatToolNameList(items: string[]): string {
+  const maxItems = 24;
+  if (items.length <= maxItems) {
+    return `${items.join(", ")}.`;
+  }
+  return `${items.slice(0, maxItems).join(", ")} (+${items.length - maxItems} more).`;
 }
 
 function inspectToolCall(


### PR DESCRIPTION
Closes #112

## Motivation

We ran a 5-task baseline benchmark against `step-3.7-flash` (392 chat requests / 15.9M prompt tokens, recorded through a local logging proxy) and found three failure loops in the agent's error-recovery path. All failures came from multi-step tool orchestration; single-step tasks were fine. This PR fixes the three feedback gaps that caused them.

### 1. `UNKNOWN_TOOL` errors give the model nothing to recover with

With Code Mode active, the top-level tools are only `exec` + `wait`, but the model's prior is Claude-Code-style top-level tools. When it called a hallucinated top-level `read_file`, the error was just `Tool 'read_file' is not registered` — the model retried hallucinated names for 13+ rounds, and one run never recovered within its 90s budget.

**Fix**: the error now lists the real visible tools and all Code Mode nested bindings; when the requested name is close (Levenshtein ≤ 2 or fuzzy score ≥ 60), it states the exact call shape — `call exec and use tools.read_file(...) inside it`. Nested-scope errors list the real nested tools with a did-you-mean hint.

### 2. Numeric-argument escalation evades `REPEATED_TOOL_CALL`

After `run_command` failures the model misdiagnosed timeouts and escalated `timeout_ms` exponentially (2e10 → 2.4e37 → 3.6e76). Each call produced a fresh fingerprint (arguments hashed verbatim), so the repeated-call guard never fired — one runaway run consumed 600s / 305 requests / ~14.8M prompt tokens before being killed.

**Fix**: fingerprint normalization collapses numeric arguments with |v| > 1e9 into a single placeholder. Legitimate values (timeouts, offsets, limits) sit far below the threshold, while escalated values all collapse into one fingerprint and the existing `repeatedToolCallLimit` fires. The block message also states explicitly that numeric-only changes keep being suppressed.

### 3. exec sandbox feedback hides tool failures

A script whose nested tool calls failed still returned `ok: true` with `Script completed`; failures were shown only as bare `✗` marks, and the recorded failure `summary` (exit codes, stderr) was dropped from the rendered output. The model could not distinguish "script returned nothing" from "tool failed" from "timed out", which directly fed failure mode 2.

**Fix**: `✗` lines now carry the failure reason; the summary counts failures (`Script completed · 2 tool calls, 1 failed tool call`); the no-result diagnostic explicitly rules out timeouts when tool calls failed; `data.failedToolCalls` is added for observability.

## Verification

- 314 core tests green (23 new), full `pnpm check` clean (oxlint, dependency-cruiser guardrails, knip, tsc, prettier)
- End-to-end re-run of the failing benchmark tasks: a locate-and-explain task that previously timed out now completes in 47s with 20 tool calls and zero wasted retries; a precise-edit task that previously hit the 30-call circuit breaker now converges in 9 calls, with two script errors correctly diagnosed from the new feedback (`import` → `require` → nested tools) and no repeated calls

## Honest boundary

These fixes make recovery fast; they do not prevent the first hallucinated call. That is a model instruction-following limit which we mitigate separately on the prompt side.

## 中文说明

对 `step-3.7-flash` 做了 5 类任务的基线实测（392 次请求 / 约 1590 万 prompt tokens，经本地记录代理），发现 agent 纠错回路有三类失败模式——失败全部集中在多步工具编排场景，单步任务正常。本 PR 修复导致这三类失败的反馈缺口：

1. **`UNKNOWN_TOOL` 报错没有给模型任何恢复信息**——Code Mode 下顶层只有 `exec`+`wait`，模型按 Claude Code 习惯调用顶层 `read_file` 后，原报错只说"未注册"，实测最多 13+ 轮无效重试。现在报错会列出真实工具清单与全部嵌套绑定，名字相近时直接给出 `tools.read_file(...)` 的正确调用方式；嵌套作用域的报错列出真实嵌套工具并给出最近匹配建议。

2. **数值微调逃逸重复调用检测**——命令失败后模型误诊为超时，指数级抬高 `timeout_ms`（2e10 → 2.4e37 → 3.6e76），每次都生成新指纹绕过 `REPEATED_TOOL_CALL` 拦截，一次失控运行烧掉 600 秒 / 305 请求 / 约 1480 万 prompt tokens。现在指纹归一化把 |数值| > 1e9 的参数折叠为占位符——合法参数（timeout/offset/limit）远低于阈值不受影响，爆炸数值全部落进同一指纹被既有上限正常拦截；拦截文案同时明确"只改数值参数也会被抑制"。

3. **exec 沙盒反馈隐藏工具失败**——脚本内嵌套工具失败仍返回 `ok: true` + `Script completed`，失败原因（exit code/stderr）被记录但没渲染进模型可见的输出。模型无法区分"脚本没返回值""工具失败""命令超时"，这直接喂养了第 2 类误诊。现在 `✗` 行带失败原因，summary 如实计数失败调用，无返回值 Diagnostic 在有失败时明确排除超时方向，并新增 `data.failedToolCalls` 结构化计数。

验证：core 314 个测试全绿（新增 23 个），`pnpm check` 全过；端到端重跑原失败任务——定位检索任务从 90s 超时变为 47s 完成且零无效重试，精确编辑任务从 30 次调用触发熔断变为 9 次收敛、两次脚本失败均凭新反馈正确归因、无重复调用。

## 诚实边界

这些修复让"踩雷后"的恢复变快，但不能阻止首次幻觉调用——那是模型指令遵循的固有限制，我们在 prompt 侧单独缓解。
